### PR TITLE
Coerce query parameter strings to respective types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install: trucegen ## Install truce globally
 
 .PHONY: test
 test: build
-	$(GO) test -race ./...
+	$(GO) test -count 5 -race ./...
 
 .PHONY: fmt
 fmt: deps ## Run go fmt -s and cue fmt all over the shop

--- a/example/client.go
+++ b/example/client.go
@@ -67,11 +67,15 @@ func (_c *Client) GetPost(ctxt context.Context, id string) (Post, error) {
 	return _rtn, _err
 }
 
-func (_c *Client) GetPosts(ctxt context.Context) ([]Post, error) {
+func (_c *Client) GetPosts(ctxt context.Context, limit int64) ([]Post, error) {
 	_u, _err := _c.host.Parse("/api/v1/posts")
 	if _err != nil {
 		return nil, _err
 	}
+
+	_query := _u.Query()
+	_query.Set("limit", fmt.Sprintf("%v", limit))
+	_u.RawQuery = _query.Encode()
 
 	var (
 		_body io.Reader
@@ -137,11 +141,15 @@ func (_c *Client) GetUser(ctxt context.Context, id string) (User, error) {
 	return _rtn, _err
 }
 
-func (_c *Client) GetUsers(ctxt context.Context) ([]User, error) {
+func (_c *Client) GetUsers(ctxt context.Context, limit int64) ([]User, error) {
 	_u, _err := _c.host.Parse("/api/v1/users")
 	if _err != nil {
 		return nil, _err
 	}
+
+	_query := _u.Query()
+	_query.Set("limit", fmt.Sprintf("%v", limit))
+	_u.RawQuery = _query.Encode()
 
 	var (
 		_body io.Reader

--- a/example/server.go
+++ b/example/server.go
@@ -6,18 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi"
 )
 
 var _ = time.After
+var _ = strconv.Itoa
 
 type Service interface {
 	GetPost(ctxt context.Context, id string) (Post, error)
-	GetPosts(ctxt context.Context) ([]Post, error)
+	GetPosts(ctxt context.Context, limit int64) ([]Post, error)
 	GetUser(ctxt context.Context, id string) (User, error)
-	GetUsers(ctxt context.Context) ([]User, error)
+	GetUsers(ctxt context.Context, limit int64) ([]User, error)
 	PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error)
 	PatchUser(ctxt context.Context, id string, user PatchUserRequest) (User, error)
 	PutPost(ctxt context.Context, post PutPostRequest) (Post, error)
@@ -63,7 +65,12 @@ func (c *Server) handleGetPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Server) handleGetPosts(w http.ResponseWriter, r *http.Request) {
-	r0, err := c.srv.GetPosts(r.Context())
+	q0 := r.URL.Query().Get("limit")
+	limit, err := strconv.ParseInt(q0, 10, 64)
+	if err != nil {
+		return
+	}
+	r0, err := c.srv.GetPosts(r.Context(), limit)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -92,7 +99,12 @@ func (c *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Server) handleGetUsers(w http.ResponseWriter, r *http.Request) {
-	r0, err := c.srv.GetUsers(r.Context())
+	q0 := r.URL.Query().Get("limit")
+	limit, err := strconv.ParseInt(q0, 10, 64)
+	if err != nil {
+		return
+	}
+	r0, err := c.srv.GetUsers(r.Context(), limit)
 	if err != nil {
 		handleError(w, err)
 		return

--- a/example/service.cue
+++ b/example/service.cue
@@ -71,13 +71,17 @@ specifications: {
 					}
 				}
 				"Get\(resourceName)s": {
+					arguments: [
+						{name: "limit", type: "int"},
+					]
 					return: {
 						name: "\(strings.ToLower(resourceName))s"
 						type: "[]\(resourceName)"
 					}
 					transports: http: {
-						path:   "/\(strings.ToLower(resourceName))s"
-						method: "GET"
+						path:                    "/\(strings.ToLower(resourceName))s"
+						method:                  "GET"
+						arguments: limit: {from: "query", var: "limit"}
 					}
 				}
 				"Put\(resourceName)": {

--- a/example/swagger.json
+++ b/example/swagger.json
@@ -226,7 +226,18 @@
                             }
                         }
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "in": "query",
+                        "description": "limit from query"
+                    }
+                ]
             },
             "put": {
                 "operationId": "PutPost",
@@ -335,7 +346,18 @@
                             }
                         }
                     }
-                }
+                },
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "in": "query",
+                        "description": "limit from query"
+                    }
+                ]
             },
             "put": {
                 "operationId": "PutUser",

--- a/example/types.go
+++ b/example/types.go
@@ -33,7 +33,7 @@ type PatchPostRequest struct {
 }
 
 type PatchUserRequest struct {
-	Age    int                    `json:"age"`
+	Age    int64                  `json:"age"`
 	Height float64                `json:"height"`
 	Labels map[string]interface{} `json:"labels"`
 	Name   string                 `json:"name"`
@@ -55,14 +55,14 @@ type PutPostRequest struct {
 }
 
 type PutUserRequest struct {
-	Age    int                    `json:"age"`
+	Age    int64                  `json:"age"`
 	Height float64                `json:"height"`
 	Labels map[string]interface{} `json:"labels"`
 	Name   string                 `json:"name"`
 }
 
 type User struct {
-	Age    int                    `json:"age"`
+	Age    int64                  `json:"age"`
 	Height float64                `json:"height"`
 	Id     string                 `json:"id"`
 	Labels map[string]interface{} `json:"labels"`

--- a/internal/generate/gocode/gotemplate/func.go
+++ b/internal/generate/gocode/gotemplate/func.go
@@ -32,6 +32,8 @@ func name(f truce.Field) (v string) {
 
 func goType(typ string) string {
 	switch typ {
+	case "int":
+		return "int64"
 	case "object":
 		return "map[string]interface{}"
 	case "timestamp", "*timestamp":

--- a/internal/generate/gocode/gotemplate/func_test.go
+++ b/internal/generate/gocode/gotemplate/func_test.go
@@ -69,6 +69,39 @@ func TestName(t *testing.T) {
 	}
 }
 
+func TestGoType(t *testing.T) {
+	testcases := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  "string",
+			out: "string",
+		},
+		{
+			in:  "int",
+			out: "int64",
+		},
+		{
+			in:  "object",
+			out: "map[string]interface{}",
+		},
+		{
+			in:  "timestamp",
+			out: "time.Time",
+		},
+		{
+			in:  "*timestamp",
+			out: "*time.Time",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, goType(tc.in), tc.out)
+		})
+	}
+}
+
 func TestSignature(t *testing.T) {
 	testcases := []struct {
 		name string
@@ -94,7 +127,7 @@ func TestSignature(t *testing.T) {
 					{Name: "b", Type: "int"},
 				},
 			},
-			out: "do(ctxt context.Context, a string, b int) (error)",
+			out: "do(ctxt context.Context, a string, b int64) (error)",
 		},
 		{
 			name: "return value",

--- a/internal/generate/gocode/gotemplate/http.go
+++ b/internal/generate/gocode/gotemplate/http.go
@@ -117,16 +117,16 @@ func (q QueryParam) FromStringVar() (v string) {
 	v = fmt.Sprintf("q%d := r.URL.Query().Get(\"%s\")\n", q.Pos, q.QueryVar)
 	switch q.Type {
 	case "int":
-		v += fmt.Sprintf("%s, err := strconv.ParseInt(q%d, 10, 64); if err != nil { return }",
+		v += fmt.Sprintf("%s, err := strconv.ParseInt(q%d, 10, 64); if err != nil { return }\n",
 			q.GoVar, q.Pos)
 	case "float64":
-		v += fmt.Sprintf("%s, err := strconv.ParseFloat(q%d, 10, 64); if err != nil { return }",
+		v += fmt.Sprintf("%s, err := strconv.ParseFloat(q%d, 10, 64); if err != nil { return }\n",
 			q.GoVar, q.Pos)
 	case "bool":
-		v += fmt.Sprintf("%s, err := strconv.ParseBool(q%d); if err != nil { return }",
+		v += fmt.Sprintf("%s, err := strconv.ParseBool(q%d); if err != nil { return }\n",
 			q.GoVar, q.Pos)
 	case "timestamp":
-		v += fmt.Sprintf("%s, err := time.Parse(time.RFC3339, q%d); if err != nil { return }",
+		v += fmt.Sprintf("%s, err := time.Parse(time.RFC3339, q%d); if err != nil { return }\n",
 			q.GoVar, q.Pos)
 	default:
 		v += fmt.Sprintf("%s := q%d", q.GoVar, q.Pos)

--- a/internal/generate/gocode/gotemplate/tmpl/client.go.tmpl
+++ b/internal/generate/gocode/gotemplate/tmpl/client.go.tmpl
@@ -61,7 +61,7 @@ func (_c *{{ $ctxt.ClientName }}) {{signature .Definition}} {
     {{ if ne (len .Query) 0 -}}
     _query := _u.Query()
     {{ range $k, $v := .Query -}}
-    _query.Set("{{$k}}", {{$v}})
+    _query.Set("{{$k}}", {{$v.ToStringVar}})
     {{ end -}}
     _u.RawQuery = _query.Encode()
     {{- end }}

--- a/internal/generate/gocode/gotemplate/tmpl/server.go.tmpl
+++ b/internal/generate/gocode/gotemplate/tmpl/server.go.tmpl
@@ -43,7 +43,7 @@ func New{{.ServerName}}(srv Service) *{{.ServerName}} {
 {{ range .Functions }}func (c *{{ $ctxt.ServerName }}) handle{{.Definition.Name}}(w http.ResponseWriter, r *http.Request) {
     {{- range .Path -}}
     {{ if eq .Type "variable" }}{{ .Var }} := chi.URLParam(r, "{{ .Value }}"){{ end }}
-    {{- end }}
+    {{ end }}
     {{- range $k, $v := .Query -}}
     {{$v.FromStringVar}}
     {{- end }}

--- a/internal/generate/gocode/gotemplate/tmpl/server.go.tmpl
+++ b/internal/generate/gocode/gotemplate/tmpl/server.go.tmpl
@@ -7,12 +7,14 @@ import (
 "encoding/json"
 "net/http"
 "time"
+"strconv"
 
 "github.com/go-chi/chi"
 {{ .Imports }}
 )
 
 var _ = time.After
+var _ = strconv.Itoa
 
 type Service interface {
     {{ range .Functions -}}
@@ -43,7 +45,7 @@ func New{{.ServerName}}(srv Service) *{{.ServerName}} {
     {{ if eq .Type "variable" }}{{ .Var }} := chi.URLParam(r, "{{ .Value }}"){{ end }}
     {{- end }}
     {{- range $k, $v := .Query -}}
-    {{ $v }} := r.URL.Query().Get("{{ $k }}")
+    {{$v.FromStringVar}}
     {{- end }}
     {{- if ne .BodyVar "" }}
     var {{ .BodyVar }} {{ .BodyType }}

--- a/internal/generate/gocode/testdata/client.go.golden
+++ b/internal/generate/gocode/testdata/client.go.golden
@@ -67,7 +67,7 @@ func (_c *ExampleClient) GetPost(ctxt context.Context, id string) (Post, error) 
 	return _rtn, _err
 }
 
-func (_c *ExampleClient) GetPosts(ctxt context.Context, limit int64) ([]Post, error) {
+func (_c *ExampleClient) GetPosts(ctxt context.Context, limit int64, since time.Time) ([]Post, error) {
 	_u, _err := _c.host.Parse("/api/v1/posts")
 	if _err != nil {
 		return nil, _err
@@ -75,6 +75,7 @@ func (_c *ExampleClient) GetPosts(ctxt context.Context, limit int64) ([]Post, er
 
 	_query := _u.Query()
 	_query.Set("limit", fmt.Sprintf("%v", limit))
+	_query.Set("timestamp", since.Format(time.RFC3339))
 	_u.RawQuery = _query.Encode()
 
 	var (
@@ -141,7 +142,7 @@ func (_c *ExampleClient) GetUser(ctxt context.Context, id string) (User, error) 
 	return _rtn, _err
 }
 
-func (_c *ExampleClient) GetUsers(ctxt context.Context, limit int64) ([]User, error) {
+func (_c *ExampleClient) GetUsers(ctxt context.Context, limit int64, since time.Time) ([]User, error) {
 	_u, _err := _c.host.Parse("/api/v1/users")
 	if _err != nil {
 		return nil, _err
@@ -149,6 +150,7 @@ func (_c *ExampleClient) GetUsers(ctxt context.Context, limit int64) ([]User, er
 
 	_query := _u.Query()
 	_query.Set("limit", fmt.Sprintf("%v", limit))
+	_query.Set("timestamp", since.Format(time.RFC3339))
 	_u.RawQuery = _query.Encode()
 
 	var (

--- a/internal/generate/gocode/testdata/client.go.golden
+++ b/internal/generate/gocode/testdata/client.go.golden
@@ -67,11 +67,15 @@ func (_c *ExampleClient) GetPost(ctxt context.Context, id string) (Post, error) 
 	return _rtn, _err
 }
 
-func (_c *ExampleClient) GetPosts(ctxt context.Context) ([]Post, error) {
+func (_c *ExampleClient) GetPosts(ctxt context.Context, limit int64) ([]Post, error) {
 	_u, _err := _c.host.Parse("/api/v1/posts")
 	if _err != nil {
 		return nil, _err
 	}
+
+	_query := _u.Query()
+	_query.Set("limit", fmt.Sprintf("%v", limit))
+	_u.RawQuery = _query.Encode()
 
 	var (
 		_body io.Reader
@@ -137,11 +141,15 @@ func (_c *ExampleClient) GetUser(ctxt context.Context, id string) (User, error) 
 	return _rtn, _err
 }
 
-func (_c *ExampleClient) GetUsers(ctxt context.Context) ([]User, error) {
+func (_c *ExampleClient) GetUsers(ctxt context.Context, limit int64) ([]User, error) {
 	_u, _err := _c.host.Parse("/api/v1/users")
 	if _err != nil {
 		return nil, _err
 	}
+
+	_query := _u.Query()
+	_query.Set("limit", fmt.Sprintf("%v", limit))
+	_u.RawQuery = _query.Encode()
 
 	var (
 		_body io.Reader

--- a/internal/generate/gocode/testdata/client.go.golden
+++ b/internal/generate/gocode/testdata/client.go.golden
@@ -180,6 +180,76 @@ func (_c *ExampleClient) GetUsers(ctxt context.Context, limit int64) ([]User, er
 	return _rtn, _err
 }
 
+func (_c *ExampleClient) NamespacedGetPost(ctxt context.Context, namespace string, id string) (Post, error) {
+	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/namespace/%v/posts/%v", namespace, id))
+	if _err != nil {
+		return Post{}, _err
+	}
+
+	var (
+		_body io.Reader
+		_resp *http.Response
+	)
+
+	_req, _err := http.NewRequest("GET", _u.String(), _body)
+	if _err != nil {
+		return Post{}, _err
+	}
+
+	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
+	if _err != nil {
+		return Post{}, _err
+	}
+
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, _resp.Body)
+		_ = _resp.Body.Close()
+	}()
+
+	if _err = _checkResponse(_resp); _err != nil {
+		return Post{}, _err
+	}
+
+	var _rtn Post
+	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
+	return _rtn, _err
+}
+
+func (_c *ExampleClient) NamespacedGetUser(ctxt context.Context, namespace string, id string) (User, error) {
+	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/namespace/%v/users/%v", namespace, id))
+	if _err != nil {
+		return User{}, _err
+	}
+
+	var (
+		_body io.Reader
+		_resp *http.Response
+	)
+
+	_req, _err := http.NewRequest("GET", _u.String(), _body)
+	if _err != nil {
+		return User{}, _err
+	}
+
+	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
+	if _err != nil {
+		return User{}, _err
+	}
+
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, _resp.Body)
+		_ = _resp.Body.Close()
+	}()
+
+	if _err = _checkResponse(_resp); _err != nil {
+		return User{}, _err
+	}
+
+	var _rtn User
+	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
+	return _rtn, _err
+}
+
 func (_c *ExampleClient) PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error) {
 	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/posts/%v", id))
 	if _err != nil {

--- a/internal/generate/gocode/testdata/server.go.golden
+++ b/internal/generate/gocode/testdata/server.go.golden
@@ -20,6 +20,8 @@ type Service interface {
 	GetPosts(ctxt context.Context, limit int64) ([]Post, error)
 	GetUser(ctxt context.Context, id string) (User, error)
 	GetUsers(ctxt context.Context, limit int64) ([]User, error)
+	NamespacedGetPost(ctxt context.Context, namespace string, id string) (Post, error)
+	NamespacedGetUser(ctxt context.Context, namespace string, id string) (User, error)
 	PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error)
 	PatchUser(ctxt context.Context, id string, user PatchUserRequest) (User, error)
 	PutPost(ctxt context.Context, post PutPostRequest) (Post, error)
@@ -41,6 +43,8 @@ func NewExampleServer(srv Service) *ExampleServer {
 	s.Router.Get("/api/v1/posts", s.handleGetPosts)
 	s.Router.Get("/api/v1/users/{id}", s.handleGetUser)
 	s.Router.Get("/api/v1/users", s.handleGetUsers)
+	s.Router.Get("/api/v1/namespace/{namespace}/posts/{id}", s.handleNamespacedGetPost)
+	s.Router.Get("/api/v1/namespace/{namespace}/users/{id}", s.handleNamespacedGetUser)
 	s.Router.Patch("/api/v1/posts/{id}", s.handlePatchPost)
 	s.Router.Patch("/api/v1/users/{id}", s.handlePatchUser)
 	s.Router.Put("/api/v1/posts", s.handlePutPost)
@@ -50,7 +54,9 @@ func NewExampleServer(srv Service) *ExampleServer {
 }
 
 func (c *ExampleServer) handleGetPost(w http.ResponseWriter, r *http.Request) {
+
 	id := chi.URLParam(r, "id")
+
 	r0, err := c.srv.GetPost(r.Context(), id)
 	if err != nil {
 		handleError(w, err)
@@ -65,6 +71,7 @@ func (c *ExampleServer) handleGetPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ExampleServer) handleGetPosts(w http.ResponseWriter, r *http.Request) {
+
 	q0 := r.URL.Query().Get("limit")
 	limit, err := strconv.ParseInt(q0, 10, 64)
 	if err != nil {
@@ -84,7 +91,9 @@ func (c *ExampleServer) handleGetPosts(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ExampleServer) handleGetUser(w http.ResponseWriter, r *http.Request) {
+
 	id := chi.URLParam(r, "id")
+
 	r0, err := c.srv.GetUser(r.Context(), id)
 	if err != nil {
 		handleError(w, err)
@@ -99,6 +108,7 @@ func (c *ExampleServer) handleGetUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ExampleServer) handleGetUsers(w http.ResponseWriter, r *http.Request) {
+
 	q0 := r.URL.Query().Get("limit")
 	limit, err := strconv.ParseInt(q0, 10, 64)
 	if err != nil {
@@ -117,8 +127,48 @@ func (c *ExampleServer) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-func (c *ExampleServer) handlePatchPost(w http.ResponseWriter, r *http.Request) {
+func (c *ExampleServer) handleNamespacedGetPost(w http.ResponseWriter, r *http.Request) {
+
+	namespace := chi.URLParam(r, "namespace")
+
 	id := chi.URLParam(r, "id")
+
+	r0, err := c.srv.NamespacedGetPost(r.Context(), namespace, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(r0); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	return
+}
+
+func (c *ExampleServer) handleNamespacedGetUser(w http.ResponseWriter, r *http.Request) {
+
+	namespace := chi.URLParam(r, "namespace")
+
+	id := chi.URLParam(r, "id")
+
+	r0, err := c.srv.NamespacedGetUser(r.Context(), namespace, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(r0); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	return
+}
+
+func (c *ExampleServer) handlePatchPost(w http.ResponseWriter, r *http.Request) {
+
+	id := chi.URLParam(r, "id")
+
 	var post PatchPostRequest
 	if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -139,7 +189,9 @@ func (c *ExampleServer) handlePatchPost(w http.ResponseWriter, r *http.Request) 
 }
 
 func (c *ExampleServer) handlePatchUser(w http.ResponseWriter, r *http.Request) {
+
 	id := chi.URLParam(r, "id")
+
 	var user PatchUserRequest
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -160,6 +212,7 @@ func (c *ExampleServer) handlePatchUser(w http.ResponseWriter, r *http.Request) 
 }
 
 func (c *ExampleServer) handlePutPost(w http.ResponseWriter, r *http.Request) {
+
 	var post PutPostRequest
 	if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -180,6 +233,7 @@ func (c *ExampleServer) handlePutPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ExampleServer) handlePutUser(w http.ResponseWriter, r *http.Request) {
+
 	var user PutUserRequest
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/generate/gocode/testdata/server.go.golden
+++ b/internal/generate/gocode/testdata/server.go.golden
@@ -17,9 +17,9 @@ var _ = strconv.Itoa
 
 type Service interface {
 	GetPost(ctxt context.Context, id string) (Post, error)
-	GetPosts(ctxt context.Context, limit int64) ([]Post, error)
+	GetPosts(ctxt context.Context, limit int64, since time.Time) ([]Post, error)
 	GetUser(ctxt context.Context, id string) (User, error)
-	GetUsers(ctxt context.Context, limit int64) ([]User, error)
+	GetUsers(ctxt context.Context, limit int64, since time.Time) ([]User, error)
 	NamespacedGetPost(ctxt context.Context, namespace string, id string) (Post, error)
 	NamespacedGetUser(ctxt context.Context, namespace string, id string) (User, error)
 	PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error)
@@ -77,7 +77,13 @@ func (c *ExampleServer) handleGetPosts(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	r0, err := c.srv.GetPosts(r.Context(), limit)
+	q1 := r.URL.Query().Get("timestamp")
+	since, err := time.Parse(time.RFC3339, q1)
+	if err != nil {
+		return
+	}
+
+	r0, err := c.srv.GetPosts(r.Context(), limit, since)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -114,7 +120,13 @@ func (c *ExampleServer) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	r0, err := c.srv.GetUsers(r.Context(), limit)
+	q1 := r.URL.Query().Get("timestamp")
+	since, err := time.Parse(time.RFC3339, q1)
+	if err != nil {
+		return
+	}
+
+	r0, err := c.srv.GetUsers(r.Context(), limit, since)
 	if err != nil {
 		handleError(w, err)
 		return

--- a/internal/generate/gocode/testdata/server.go.golden
+++ b/internal/generate/gocode/testdata/server.go.golden
@@ -6,18 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi"
 )
 
 var _ = time.After
+var _ = strconv.Itoa
 
 type Service interface {
 	GetPost(ctxt context.Context, id string) (Post, error)
-	GetPosts(ctxt context.Context) ([]Post, error)
+	GetPosts(ctxt context.Context, limit int64) ([]Post, error)
 	GetUser(ctxt context.Context, id string) (User, error)
-	GetUsers(ctxt context.Context) ([]User, error)
+	GetUsers(ctxt context.Context, limit int64) ([]User, error)
 	PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error)
 	PatchUser(ctxt context.Context, id string, user PatchUserRequest) (User, error)
 	PutPost(ctxt context.Context, post PutPostRequest) (Post, error)
@@ -63,7 +65,12 @@ func (c *ExampleServer) handleGetPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ExampleServer) handleGetPosts(w http.ResponseWriter, r *http.Request) {
-	r0, err := c.srv.GetPosts(r.Context())
+	q0 := r.URL.Query().Get("limit")
+	limit, err := strconv.ParseInt(q0, 10, 64)
+	if err != nil {
+		return
+	}
+	r0, err := c.srv.GetPosts(r.Context(), limit)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -92,7 +99,12 @@ func (c *ExampleServer) handleGetUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *ExampleServer) handleGetUsers(w http.ResponseWriter, r *http.Request) {
-	r0, err := c.srv.GetUsers(r.Context())
+	q0 := r.URL.Query().Get("limit")
+	limit, err := strconv.ParseInt(q0, 10, 64)
+	if err != nil {
+		return
+	}
+	r0, err := c.srv.GetUsers(r.Context(), limit)
 	if err != nil {
 		handleError(w, err)
 		return

--- a/internal/generate/gocode/testdata/service.cue
+++ b/internal/generate/gocode/testdata/service.cue
@@ -115,6 +115,22 @@ specifications: {
 						}
 					}
 				}
+				"NamespacedGet\(resourceName)": {
+					arguments: [
+						{name: "namespace", type: "string"},
+						{name: "id", type:        "string"},
+					]
+					return: {
+						name: "\(strings.ToLower(resourceName))"
+						type: resourceName
+					}
+					transports: http: {
+						path:                        "/namespace/{namespace}/\(strings.ToLower(resourceName))s/{id}"
+						method:                      "GET"
+						arguments: namespace: {from: "path", var: "namespace"}
+						arguments: id: {from: "path", var: "id"}
+					}
+				}
 			}
 		}
 		types: {

--- a/internal/generate/gocode/testdata/service.cue
+++ b/internal/generate/gocode/testdata/service.cue
@@ -23,20 +23,19 @@ import "strings"
 
 outputs:
 	"example": "1": {
-		openapi: {
-			version: 3
-			path:    "example/swagger.json"
-		}
 		go: {
-			types: {path: "example/types.go", pkg: "example"}
+			types: {
+				path: "types.go.golden"
+				pkg:  "example"
+			}
 			server: {
-				path: "example/server.go"
-				type: "Server"
+				path: "server.go.golden"
+				type: "ExampleServer"
 				pkg:  "example"
 			}
 			client: {
-				path: "example/client.go"
-				type: "Client"
+				path: "client.go.golden"
+				type: "ExampleClient"
 				pkg:  "example"
 			}
 		}
@@ -71,13 +70,17 @@ specifications: {
 					}
 				}
 				"Get\(resourceName)s": {
+					arguments: [
+						{name: "limit", type: "int"},
+					]
 					return: {
 						name: "\(strings.ToLower(resourceName))s"
 						type: "[]\(resourceName)"
 					}
 					transports: http: {
-						path:   "/\(strings.ToLower(resourceName))s"
-						method: "GET"
+						path:                    "/\(strings.ToLower(resourceName))s"
+						method:                  "GET"
+						arguments: limit: {from: "query", var: "limit"}
 					}
 				}
 				"Put\(resourceName)": {

--- a/internal/generate/gocode/testdata/service.cue
+++ b/internal/generate/gocode/testdata/service.cue
@@ -72,6 +72,7 @@ specifications: {
 				"Get\(resourceName)s": {
 					arguments: [
 						{name: "limit", type: "int"},
+						{name: "since", type: "timestamp"},
 					]
 					return: {
 						name: "\(strings.ToLower(resourceName))s"
@@ -81,6 +82,7 @@ specifications: {
 						path:                    "/\(strings.ToLower(resourceName))s"
 						method:                  "GET"
 						arguments: limit: {from: "query", var: "limit"}
+						arguments: since: {from: "query", var: "timestamp"}
 					}
 				}
 				"Put\(resourceName)": {

--- a/internal/generate/gocode/testdata/types.go.golden
+++ b/internal/generate/gocode/testdata/types.go.golden
@@ -33,7 +33,7 @@ type PatchPostRequest struct {
 }
 
 type PatchUserRequest struct {
-	Age    int                    `json:"age"`
+	Age    int64                  `json:"age"`
 	Height float64                `json:"height"`
 	Labels map[string]interface{} `json:"labels"`
 	Name   string                 `json:"name"`
@@ -55,14 +55,14 @@ type PutPostRequest struct {
 }
 
 type PutUserRequest struct {
-	Age    int                    `json:"age"`
+	Age    int64                  `json:"age"`
 	Height float64                `json:"height"`
 	Labels map[string]interface{} `json:"labels"`
 	Name   string                 `json:"name"`
 }
 
 type User struct {
-	Age    int                    `json:"age"`
+	Age    int64                  `json:"age"`
 	Height float64                `json:"height"`
 	Id     string                 `json:"id"`
 	Labels map[string]interface{} `json:"labels"`


### PR DESCRIPTION
This adds coercion of some types when moving them to and from query parameters.

For example, a query parameter of type `int` will be coerced from a string in the service using `strconv.ParseInt(...)`.
The client will massage most types using `fmt.Strintf("%v")`,
Except for `timestamp` which it uses the `time.Time.Format` method to encode `RFC3339`.