### PR TITLE
Move to a layered call approach for the client template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
-          go-version: 1.16.0-beta1
+          go-version: 1.16.0-rc1
       - name: Lint
         run: |
           go get honnef.co/go/tools/cmd/staticcheck

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO ?= go1.16beta1
+GO ?= go1.16rc1
 export GO
 
 .PHONY: build

--- a/internal/generate/gocode/gotemplate/func_test.go
+++ b/internal/generate/gocode/gotemplate/func_test.go
@@ -7,7 +7,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestArgs(t *testing.T) {
+func TestPosArgs(t *testing.T) {
 	testcases := []struct {
 		name string
 		in   []truce.Field
@@ -18,7 +18,7 @@ func TestArgs(t *testing.T) {
 			in: []truce.Field{
 				{Name: "a", Type: "string"},
 			},
-			out: "a",
+			out: "v0",
 		},
 		{
 			name: "multiple fields",
@@ -26,7 +26,7 @@ func TestArgs(t *testing.T) {
 				{Name: "a", Type: "string"},
 				{Name: "b", Type: "string"},
 			},
-			out: "a, b",
+			out: "v0, v1",
 		},
 		{
 			name: "no fields",
@@ -36,9 +36,7 @@ func TestArgs(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			v := args(truce.Function{
-				Arguments: tc.in,
-			})
+			v := posArgs(tc.in)
 			assert.Equal(t, v, tc.out)
 		})
 	}
@@ -181,29 +179,29 @@ func TestPath(t *testing.T) {
 		{
 			name: "single variable",
 			in: Path{
-				{Var: "x", Type: "variable", Value: "a"},
+				{VarPos: 0, Var: "x", Type: "variable", Value: "a"},
 			},
-			out: `fmt.Sprintf("/%v", x)`,
+			out: `fmt.Sprintf("/%v", v0)`,
 		},
 		{
 			name: "multiple variables",
 			in: Path{
-				{Var: "x", Type: "variable", Value: "a"},
-				{Var: "y", Type: "variable", Value: "b"},
-				{Var: "z", Type: "variable", Value: "c"},
+				{VarPos: 0, Var: "x", Type: "variable", Value: "a"},
+				{VarPos: 1, Var: "y", Type: "variable", Value: "b"},
+				{VarPos: 2, Var: "z", Type: "variable", Value: "c"},
 			},
-			out: `fmt.Sprintf("/%v/%v/%v", x, y, z)`,
+			out: `fmt.Sprintf("/%v/%v/%v", v0, v1, v2)`,
 		},
 		{
 			name: "variables and static elements",
 			in: Path{
 				{Value: "api", Type: "static"},
-				{Var: "x", Type: "variable", Value: "a"},
-				{Var: "y", Type: "variable", Value: "b"},
+				{VarPos: 0, Var: "x", Type: "variable", Value: "a"},
+				{VarPos: 1, Var: "y", Type: "variable", Value: "b"},
 				{Value: "private", Type: "static"},
-				{Var: "z", Type: "variable", Value: "c"},
+				{VarPos: 2, Var: "z", Type: "variable", Value: "c"},
 			},
-			out: `fmt.Sprintf("/api/%v/%v/private/%v", x, y, z)`,
+			out: `fmt.Sprintf("/api/%v/%v/private/%v", v0, v1, v2)`,
 		},
 	}
 	for _, tc := range testcases {

--- a/internal/generate/gocode/gotemplate/tmpl/client.go.tmpl
+++ b/internal/generate/gocode/gotemplate/tmpl/client.go.tmpl
@@ -36,83 +36,87 @@ func New{{.ClientName}}(host string) (*{{.ClientName}}, error) {
 {{ define "errorReturn" }}
 {{- if .HasReturn -}}
     {{- if .ReturnIsPtr -}}
-        return nil, _err
+        return nil, err
     {{ else }}
 	{{- $goType := goType .ReturnType -}}
 	{{- if stringHasPrefix $goType "[]" }}
-        return nil, _err
+        return nil, err
 	{{- else }}
-        return {{ goType .ReturnType }}{}, _err
+        return {{ goType .ReturnType }}{}, err
 	{{- end }}
     {{- end }}
 {{ else }}
-    return _err
+    return err
 {{- end -}}
 {{ end }}
 
 {{ $ctxt := . }}
 {{- range .Functions }}
-func (_c *{{ $ctxt.ClientName }}) {{signature .Definition}} {
-    _u, _err := _c.host.Parse({{ pathJoin .Path }})
-    if _err != nil {
+func (c *{{ $ctxt.ClientName }}) {{ signature .Definition }} {
+    return c.{{ callUnexported .Definition }}
+}
+
+func (c *{{ $ctxt.ClientName }}) {{ unexportedSignature .Definition }} {
+    u, err := c.host.Parse({{ pathJoin .Path }})
+    if err != nil {
         {{- template "errorReturn" . -}}
     }
 
     {{ if ne (len .Query) 0 -}}
-    _query := _u.Query()
+    query := u.Query()
     {{ range $k, $v := .Query -}}
-    _query.Set("{{$k}}", {{$v.ToStringVar}})
+    query.Set("{{ $k }}", {{ $v.ToStringVar }})
     {{ end -}}
-    _u.RawQuery = _query.Encode()
+    u.RawQuery = query.Encode()
     {{- end }}
 
     var (
-        _body io.Reader
-        _resp *http.Response
+        body io.Reader
+        resp *http.Response
     )
 
     {{ if ne .BodyVar "" -}}
-    _buf := &bytes.Buffer{}
-    _body = _buf
-    if _err = json.NewEncoder(_buf).Encode({{ .BodyVar }}); _err != nil {
+    buf := &bytes.Buffer{}
+    body = buf
+    if err = json.NewEncoder(buf).Encode({{ .BodyVar }}); err != nil {
         {{- template "errorReturn" . -}}
     }
     {{- end }}
 
-    _req, _err := http.NewRequest("{{ .Method }}", _u.String(), _body)
-    if _err != nil {
+    req, err := http.NewRequest("{{ .Method }}", u.String(), body)
+    if err != nil {
         {{- template "errorReturn" . -}}
     }
 
-    _resp, _err = _c.client.Do(_req.WithContext(ctxt))
-    if _err != nil {
+    resp, err = c.client.Do(req.WithContext(ctxt))
+    if err != nil {
         {{- template "errorReturn" . -}}
     }
 
     defer func(){
-        _, _ = io.Copy(ioutil.Discard, _resp.Body)
-        _ = _resp.Body.Close()
+        _, _ = io.Copy(ioutil.Discard, resp.Body)
+        _ = resp.Body.Close()
     }()
 
-    if _err = _checkResponse(_resp); _err != nil {
+    if err = checkResponse(resp); err != nil {
         {{- template "errorReturn" . -}}
     }
 
     {{ if .HasReturn -}}
     {{ if .ReturnIsPtr -}}
-    _rtn := &{{goType  .ReturnType }}{}
+    rtn := &{{goType  .ReturnType }}{}
 	{{ else }}
-	var _rtn {{goType  .ReturnType }}
+	var rtn {{goType  .ReturnType }}
     {{- end }}
-    _err = json.NewDecoder(_resp.Body).Decode({{ if not .ReturnIsPtr }}&{{ end }}_rtn)
-    return _rtn, _err
+    err = json.NewDecoder(resp.Body).Decode({{ if not .ReturnIsPtr }}&{{ end }}rtn)
+    return rtn, err
     {{ else }}
     return nil
     {{- end -}}
 }
 {{ end }}
 
-func _checkResponse(resp *http.Response) (error) {
+func checkResponse(resp *http.Response) (error) {
     switch resp.StatusCode {
     case http.StatusOK:
         return nil

--- a/internal/generate/gocode/gotemplate/tmpl/server.go.tmpl
+++ b/internal/generate/gocode/gotemplate/tmpl/server.go.tmpl
@@ -34,18 +34,18 @@ func New{{.ServerName}}(srv Service) *{{.ServerName}} {
     }
 
     {{ range .Functions -}}
-    s.Router.{{method .}}("{{.Path}}", s.handle{{.Definition.Name}})
+    s.Router.{{method .}}("{{ .Path }}", s.handle{{.Definition.Name}})
     {{end}}
 
     return s
 }
 
-{{ range .Functions }}func (c *{{ $ctxt.ServerName }}) handle{{.Definition.Name}}(w http.ResponseWriter, r *http.Request) {
+{{ range .Functions }}func (c *{{ $ctxt.ServerName }}) handle{{ .Definition.Name }}(w http.ResponseWriter, r *http.Request) {
     {{- range .Path -}}
-    {{ if eq .Type "variable" }}{{ .Var }} := chi.URLParam(r, "{{ .Value }}"){{ end }}
+    {{ if eq .Type "variable" }}v{{ .VarPos }} := chi.URLParam(r, "{{ .Value }}"){{ end }}
     {{ end }}
     {{- range $k, $v := .Query -}}
-    {{$v.FromStringVar}}
+    {{ $v.FromStringVar }}
     {{- end }}
     {{- if ne .BodyVar "" }}
     var {{ .BodyVar }} {{ .BodyType }}
@@ -54,7 +54,7 @@ func New{{.ServerName}}(srv Service) *{{.ServerName}} {
         return
     }
     {{ end }}
-	r0, err := c.srv.{{ .Definition.Name }}(r.Context(), {{ args .Definition }})
+	r0, err := c.srv.{{ .Definition.Name }}(r.Context(), {{ .Definition.Arguments | posArgs }})
 	if err != nil {
 		handleError(w, err)
 		return

--- a/internal/generate/gocode/testdata/client.go.golden
+++ b/internal/generate/gocode/testdata/client.go.golden
@@ -32,391 +32,431 @@ func NewExampleClient(host string) (*ExampleClient, error) {
 	return &ExampleClient{client: http.DefaultClient, host: u}, nil
 }
 
-func (_c *ExampleClient) GetPost(ctxt context.Context, id string) (Post, error) {
-	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/posts/%v", id))
-	if _err != nil {
-		return Post{}, _err
+func (c *ExampleClient) GetPost(ctxt context.Context, id string) (Post, error) {
+	return c.getPost(ctxt, id)
+}
+
+func (c *ExampleClient) getPost(ctxt context.Context, v0 string) (Post, error) {
+	u, err := c.host.Parse(fmt.Sprintf("/api/v1/posts/%v", v0))
+	if err != nil {
+		return Post{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_req, _err := http.NewRequest("GET", _u.String(), _body)
-	if _err != nil {
-		return Post{}, _err
+	req, err := http.NewRequest("GET", u.String(), body)
+	if err != nil {
+		return Post{}, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return Post{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return Post{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return Post{}, _err
+	if err = checkResponse(resp); err != nil {
+		return Post{}, err
 	}
 
-	var _rtn Post
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn Post
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) GetPosts(ctxt context.Context, limit int64, since time.Time) ([]Post, error) {
-	_u, _err := _c.host.Parse("/api/v1/posts")
-	if _err != nil {
-		return nil, _err
+func (c *ExampleClient) GetPosts(ctxt context.Context, limit int64, since time.Time) ([]Post, error) {
+	return c.getPosts(ctxt, limit, since)
+}
+
+func (c *ExampleClient) getPosts(ctxt context.Context, v0 int64, v1 time.Time) ([]Post, error) {
+	u, err := c.host.Parse("/api/v1/posts")
+	if err != nil {
+		return nil, err
 	}
 
-	_query := _u.Query()
-	_query.Set("limit", fmt.Sprintf("%v", limit))
-	_query.Set("timestamp", since.Format(time.RFC3339))
-	_u.RawQuery = _query.Encode()
+	query := u.Query()
+	query.Set("limit", fmt.Sprintf("%v", v0))
+	query.Set("timestamp", v1.Format(time.RFC3339))
+	u.RawQuery = query.Encode()
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_req, _err := http.NewRequest("GET", _u.String(), _body)
-	if _err != nil {
-		return nil, _err
+	req, err := http.NewRequest("GET", u.String(), body)
+	if err != nil {
+		return nil, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return nil, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return nil, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return nil, _err
+	if err = checkResponse(resp); err != nil {
+		return nil, err
 	}
 
-	var _rtn []Post
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn []Post
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) GetUser(ctxt context.Context, id string) (User, error) {
-	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/users/%v", id))
-	if _err != nil {
-		return User{}, _err
-	}
-
-	var (
-		_body io.Reader
-		_resp *http.Response
-	)
-
-	_req, _err := http.NewRequest("GET", _u.String(), _body)
-	if _err != nil {
-		return User{}, _err
-	}
-
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return User{}, _err
-	}
-
-	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
-	}()
-
-	if _err = _checkResponse(_resp); _err != nil {
-		return User{}, _err
-	}
-
-	var _rtn User
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+func (c *ExampleClient) GetUser(ctxt context.Context, id string) (User, error) {
+	return c.getUser(ctxt, id)
 }
 
-func (_c *ExampleClient) GetUsers(ctxt context.Context, limit int64, since time.Time) ([]User, error) {
-	_u, _err := _c.host.Parse("/api/v1/users")
-	if _err != nil {
-		return nil, _err
-	}
-
-	_query := _u.Query()
-	_query.Set("limit", fmt.Sprintf("%v", limit))
-	_query.Set("timestamp", since.Format(time.RFC3339))
-	_u.RawQuery = _query.Encode()
-
-	var (
-		_body io.Reader
-		_resp *http.Response
-	)
-
-	_req, _err := http.NewRequest("GET", _u.String(), _body)
-	if _err != nil {
-		return nil, _err
-	}
-
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return nil, _err
-	}
-
-	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
-	}()
-
-	if _err = _checkResponse(_resp); _err != nil {
-		return nil, _err
-	}
-
-	var _rtn []User
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
-}
-
-func (_c *ExampleClient) NamespacedGetPost(ctxt context.Context, namespace string, id string) (Post, error) {
-	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/namespace/%v/posts/%v", namespace, id))
-	if _err != nil {
-		return Post{}, _err
+func (c *ExampleClient) getUser(ctxt context.Context, v0 string) (User, error) {
+	u, err := c.host.Parse(fmt.Sprintf("/api/v1/users/%v", v0))
+	if err != nil {
+		return User{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_req, _err := http.NewRequest("GET", _u.String(), _body)
-	if _err != nil {
-		return Post{}, _err
+	req, err := http.NewRequest("GET", u.String(), body)
+	if err != nil {
+		return User{}, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return Post{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return User{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return Post{}, _err
+	if err = checkResponse(resp); err != nil {
+		return User{}, err
 	}
 
-	var _rtn Post
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn User
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) NamespacedGetUser(ctxt context.Context, namespace string, id string) (User, error) {
-	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/namespace/%v/users/%v", namespace, id))
-	if _err != nil {
-		return User{}, _err
+func (c *ExampleClient) GetUsers(ctxt context.Context, limit int64, since time.Time) ([]User, error) {
+	return c.getUsers(ctxt, limit, since)
+}
+
+func (c *ExampleClient) getUsers(ctxt context.Context, v0 int64, v1 time.Time) ([]User, error) {
+	u, err := c.host.Parse("/api/v1/users")
+	if err != nil {
+		return nil, err
+	}
+
+	query := u.Query()
+	query.Set("limit", fmt.Sprintf("%v", v0))
+	query.Set("timestamp", v1.Format(time.RFC3339))
+	u.RawQuery = query.Encode()
+
+	var (
+		body io.Reader
+		resp *http.Response
+	)
+
+	req, err := http.NewRequest("GET", u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if err = checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var rtn []User
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
+}
+
+func (c *ExampleClient) NamespacedGetPost(ctxt context.Context, namespace string, id string) (Post, error) {
+	return c.namespacedGetPost(ctxt, namespace, id)
+}
+
+func (c *ExampleClient) namespacedGetPost(ctxt context.Context, v0 string, v1 string) (Post, error) {
+	u, err := c.host.Parse(fmt.Sprintf("/api/v1/namespace/%v/posts/%v", v0, v1))
+	if err != nil {
+		return Post{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_req, _err := http.NewRequest("GET", _u.String(), _body)
-	if _err != nil {
-		return User{}, _err
+	req, err := http.NewRequest("GET", u.String(), body)
+	if err != nil {
+		return Post{}, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return User{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return Post{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return User{}, _err
+	if err = checkResponse(resp); err != nil {
+		return Post{}, err
 	}
 
-	var _rtn User
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn Post
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error) {
-	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/posts/%v", id))
-	if _err != nil {
-		return Post{}, _err
+func (c *ExampleClient) NamespacedGetUser(ctxt context.Context, namespace string, id string) (User, error) {
+	return c.namespacedGetUser(ctxt, namespace, id)
+}
+
+func (c *ExampleClient) namespacedGetUser(ctxt context.Context, v0 string, v1 string) (User, error) {
+	u, err := c.host.Parse(fmt.Sprintf("/api/v1/namespace/%v/users/%v", v0, v1))
+	if err != nil {
+		return User{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_buf := &bytes.Buffer{}
-	_body = _buf
-	if _err = json.NewEncoder(_buf).Encode(post); _err != nil {
-		return Post{}, _err
+	req, err := http.NewRequest("GET", u.String(), body)
+	if err != nil {
+		return User{}, err
 	}
 
-	_req, _err := http.NewRequest("PATCH", _u.String(), _body)
-	if _err != nil {
-		return Post{}, _err
-	}
-
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return Post{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return User{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return Post{}, _err
+	if err = checkResponse(resp); err != nil {
+		return User{}, err
 	}
 
-	var _rtn Post
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn User
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) PatchUser(ctxt context.Context, id string, user PatchUserRequest) (User, error) {
-	_u, _err := _c.host.Parse(fmt.Sprintf("/api/v1/users/%v", id))
-	if _err != nil {
-		return User{}, _err
+func (c *ExampleClient) PatchPost(ctxt context.Context, id string, post PatchPostRequest) (Post, error) {
+	return c.patchPost(ctxt, id, post)
+}
+
+func (c *ExampleClient) patchPost(ctxt context.Context, v0 string, v1 PatchPostRequest) (Post, error) {
+	u, err := c.host.Parse(fmt.Sprintf("/api/v1/posts/%v", v0))
+	if err != nil {
+		return Post{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_buf := &bytes.Buffer{}
-	_body = _buf
-	if _err = json.NewEncoder(_buf).Encode(user); _err != nil {
-		return User{}, _err
+	buf := &bytes.Buffer{}
+	body = buf
+	if err = json.NewEncoder(buf).Encode(v1); err != nil {
+		return Post{}, err
 	}
 
-	_req, _err := http.NewRequest("PATCH", _u.String(), _body)
-	if _err != nil {
-		return User{}, _err
+	req, err := http.NewRequest("PATCH", u.String(), body)
+	if err != nil {
+		return Post{}, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return User{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return Post{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return User{}, _err
+	if err = checkResponse(resp); err != nil {
+		return Post{}, err
 	}
 
-	var _rtn User
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn Post
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) PutPost(ctxt context.Context, post PutPostRequest) (Post, error) {
-	_u, _err := _c.host.Parse("/api/v1/posts")
-	if _err != nil {
-		return Post{}, _err
+func (c *ExampleClient) PatchUser(ctxt context.Context, id string, user PatchUserRequest) (User, error) {
+	return c.patchUser(ctxt, id, user)
+}
+
+func (c *ExampleClient) patchUser(ctxt context.Context, v0 string, v1 PatchUserRequest) (User, error) {
+	u, err := c.host.Parse(fmt.Sprintf("/api/v1/users/%v", v0))
+	if err != nil {
+		return User{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_buf := &bytes.Buffer{}
-	_body = _buf
-	if _err = json.NewEncoder(_buf).Encode(post); _err != nil {
-		return Post{}, _err
+	buf := &bytes.Buffer{}
+	body = buf
+	if err = json.NewEncoder(buf).Encode(v1); err != nil {
+		return User{}, err
 	}
 
-	_req, _err := http.NewRequest("PUT", _u.String(), _body)
-	if _err != nil {
-		return Post{}, _err
+	req, err := http.NewRequest("PATCH", u.String(), body)
+	if err != nil {
+		return User{}, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return Post{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return User{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return Post{}, _err
+	if err = checkResponse(resp); err != nil {
+		return User{}, err
 	}
 
-	var _rtn Post
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn User
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func (_c *ExampleClient) PutUser(ctxt context.Context, user PutUserRequest) (User, error) {
-	_u, _err := _c.host.Parse("/api/v1/users")
-	if _err != nil {
-		return User{}, _err
+func (c *ExampleClient) PutPost(ctxt context.Context, post PutPostRequest) (Post, error) {
+	return c.putPost(ctxt, post)
+}
+
+func (c *ExampleClient) putPost(ctxt context.Context, v0 PutPostRequest) (Post, error) {
+	u, err := c.host.Parse("/api/v1/posts")
+	if err != nil {
+		return Post{}, err
 	}
 
 	var (
-		_body io.Reader
-		_resp *http.Response
+		body io.Reader
+		resp *http.Response
 	)
 
-	_buf := &bytes.Buffer{}
-	_body = _buf
-	if _err = json.NewEncoder(_buf).Encode(user); _err != nil {
-		return User{}, _err
+	buf := &bytes.Buffer{}
+	body = buf
+	if err = json.NewEncoder(buf).Encode(v0); err != nil {
+		return Post{}, err
 	}
 
-	_req, _err := http.NewRequest("PUT", _u.String(), _body)
-	if _err != nil {
-		return User{}, _err
+	req, err := http.NewRequest("PUT", u.String(), body)
+	if err != nil {
+		return Post{}, err
 	}
 
-	_resp, _err = _c.client.Do(_req.WithContext(ctxt))
-	if _err != nil {
-		return User{}, _err
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return Post{}, err
 	}
 
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, _resp.Body)
-		_ = _resp.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
-	if _err = _checkResponse(_resp); _err != nil {
-		return User{}, _err
+	if err = checkResponse(resp); err != nil {
+		return Post{}, err
 	}
 
-	var _rtn User
-	_err = json.NewDecoder(_resp.Body).Decode(&_rtn)
-	return _rtn, _err
+	var rtn Post
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
 }
 
-func _checkResponse(resp *http.Response) error {
+func (c *ExampleClient) PutUser(ctxt context.Context, user PutUserRequest) (User, error) {
+	return c.putUser(ctxt, user)
+}
+
+func (c *ExampleClient) putUser(ctxt context.Context, v0 PutUserRequest) (User, error) {
+	u, err := c.host.Parse("/api/v1/users")
+	if err != nil {
+		return User{}, err
+	}
+
+	var (
+		body io.Reader
+		resp *http.Response
+	)
+
+	buf := &bytes.Buffer{}
+	body = buf
+	if err = json.NewEncoder(buf).Encode(v0); err != nil {
+		return User{}, err
+	}
+
+	req, err := http.NewRequest("PUT", u.String(), body)
+	if err != nil {
+		return User{}, err
+	}
+
+	resp, err = c.client.Do(req.WithContext(ctxt))
+	if err != nil {
+		return User{}, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if err = checkResponse(resp); err != nil {
+		return User{}, err
+	}
+
+	var rtn User
+	err = json.NewDecoder(resp.Body).Decode(&rtn)
+	return rtn, err
+}
+
+func checkResponse(resp *http.Response) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return nil

--- a/internal/generate/gocode/testdata/server.go.golden
+++ b/internal/generate/gocode/testdata/server.go.golden
@@ -55,9 +55,9 @@ func NewExampleServer(srv Service) *ExampleServer {
 
 func (c *ExampleServer) handleGetPost(w http.ResponseWriter, r *http.Request) {
 
-	id := chi.URLParam(r, "id")
+	v0 := chi.URLParam(r, "id")
 
-	r0, err := c.srv.GetPost(r.Context(), id)
+	r0, err := c.srv.GetPost(r.Context(), v0)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -73,17 +73,17 @@ func (c *ExampleServer) handleGetPost(w http.ResponseWriter, r *http.Request) {
 func (c *ExampleServer) handleGetPosts(w http.ResponseWriter, r *http.Request) {
 
 	q0 := r.URL.Query().Get("limit")
-	limit, err := strconv.ParseInt(q0, 10, 64)
+	v0, err := strconv.ParseInt(q0, 10, 64)
 	if err != nil {
 		return
 	}
 	q1 := r.URL.Query().Get("timestamp")
-	since, err := time.Parse(time.RFC3339, q1)
+	v1, err := time.Parse(time.RFC3339, q1)
 	if err != nil {
 		return
 	}
 
-	r0, err := c.srv.GetPosts(r.Context(), limit, since)
+	r0, err := c.srv.GetPosts(r.Context(), v0, v1)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -98,9 +98,9 @@ func (c *ExampleServer) handleGetPosts(w http.ResponseWriter, r *http.Request) {
 
 func (c *ExampleServer) handleGetUser(w http.ResponseWriter, r *http.Request) {
 
-	id := chi.URLParam(r, "id")
+	v0 := chi.URLParam(r, "id")
 
-	r0, err := c.srv.GetUser(r.Context(), id)
+	r0, err := c.srv.GetUser(r.Context(), v0)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -116,17 +116,17 @@ func (c *ExampleServer) handleGetUser(w http.ResponseWriter, r *http.Request) {
 func (c *ExampleServer) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 
 	q0 := r.URL.Query().Get("limit")
-	limit, err := strconv.ParseInt(q0, 10, 64)
+	v0, err := strconv.ParseInt(q0, 10, 64)
 	if err != nil {
 		return
 	}
 	q1 := r.URL.Query().Get("timestamp")
-	since, err := time.Parse(time.RFC3339, q1)
+	v1, err := time.Parse(time.RFC3339, q1)
 	if err != nil {
 		return
 	}
 
-	r0, err := c.srv.GetUsers(r.Context(), limit, since)
+	r0, err := c.srv.GetUsers(r.Context(), v0, v1)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -141,11 +141,11 @@ func (c *ExampleServer) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 
 func (c *ExampleServer) handleNamespacedGetPost(w http.ResponseWriter, r *http.Request) {
 
-	namespace := chi.URLParam(r, "namespace")
+	v0 := chi.URLParam(r, "namespace")
 
-	id := chi.URLParam(r, "id")
+	v1 := chi.URLParam(r, "id")
 
-	r0, err := c.srv.NamespacedGetPost(r.Context(), namespace, id)
+	r0, err := c.srv.NamespacedGetPost(r.Context(), v0, v1)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -160,11 +160,11 @@ func (c *ExampleServer) handleNamespacedGetPost(w http.ResponseWriter, r *http.R
 
 func (c *ExampleServer) handleNamespacedGetUser(w http.ResponseWriter, r *http.Request) {
 
-	namespace := chi.URLParam(r, "namespace")
+	v0 := chi.URLParam(r, "namespace")
 
-	id := chi.URLParam(r, "id")
+	v1 := chi.URLParam(r, "id")
 
-	r0, err := c.srv.NamespacedGetUser(r.Context(), namespace, id)
+	r0, err := c.srv.NamespacedGetUser(r.Context(), v0, v1)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -179,15 +179,15 @@ func (c *ExampleServer) handleNamespacedGetUser(w http.ResponseWriter, r *http.R
 
 func (c *ExampleServer) handlePatchPost(w http.ResponseWriter, r *http.Request) {
 
-	id := chi.URLParam(r, "id")
+	v0 := chi.URLParam(r, "id")
 
-	var post PatchPostRequest
-	if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+	var v1 PatchPostRequest
+	if err := json.NewDecoder(r.Body).Decode(&v1); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	r0, err := c.srv.PatchPost(r.Context(), id, post)
+	r0, err := c.srv.PatchPost(r.Context(), v0, v1)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -202,15 +202,15 @@ func (c *ExampleServer) handlePatchPost(w http.ResponseWriter, r *http.Request) 
 
 func (c *ExampleServer) handlePatchUser(w http.ResponseWriter, r *http.Request) {
 
-	id := chi.URLParam(r, "id")
+	v0 := chi.URLParam(r, "id")
 
-	var user PatchUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+	var v1 PatchUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&v1); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	r0, err := c.srv.PatchUser(r.Context(), id, user)
+	r0, err := c.srv.PatchUser(r.Context(), v0, v1)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -225,13 +225,13 @@ func (c *ExampleServer) handlePatchUser(w http.ResponseWriter, r *http.Request) 
 
 func (c *ExampleServer) handlePutPost(w http.ResponseWriter, r *http.Request) {
 
-	var post PutPostRequest
-	if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+	var v0 PutPostRequest
+	if err := json.NewDecoder(r.Body).Decode(&v0); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	r0, err := c.srv.PutPost(r.Context(), post)
+	r0, err := c.srv.PutPost(r.Context(), v0)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -246,13 +246,13 @@ func (c *ExampleServer) handlePutPost(w http.ResponseWriter, r *http.Request) {
 
 func (c *ExampleServer) handlePutUser(w http.ResponseWriter, r *http.Request) {
 
-	var user PutUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+	var v0 PutUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&v0); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	r0, err := c.srv.PutUser(r.Context(), user)
+	r0, err := c.srv.PutUser(r.Context(), v0)
 	if err != nil {
 		handleError(w, err)
 		return


### PR DESCRIPTION
Instead of prefixing everything with underscore, I've created a separate unexported method that uses the positional arguments. The exported companion has named arguments.

I've shifted some things around in how these variable names get derived. There's likely still some work to do here, but the generated code doesn't look so insane.